### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete string escaping or encoding

### DIFF
--- a/apps/frontend-nextjs/app/components/lov/lov.tsx
+++ b/apps/frontend-nextjs/app/components/lov/lov.tsx
@@ -201,7 +201,7 @@ export const lovdataBase = (
   } else if (codelist.utils.isRundskriv(nationalLaw)) {
     return env.lovdataRundskrivBaseUrl + lovId
   } else if (codelist.utils.isRettskilde(nationalLaw)) {
-    const base = env.lovdataRettskildeBaseUrl.replace('%23', '#').replace(/\/#document.*/, '')
+    const base = env.lovdataRettskildeBaseUrl.replace(/%23/g, '#').replace(/\/#document.*/, '')
     return `${base}/#document/${lovId}`
   } else {
     return env.lovdataLovBaseUrl + lovId


### PR DESCRIPTION
Potential fix for [https://github.com/navikt/etterlevelse/security/code-scanning/8](https://github.com/navikt/etterlevelse/security/code-scanning/8)

Use a global replacement so all `%23` occurrences are decoded, not just the first.  
Best fix in this file: update line 204 in `apps/frontend-nextjs/app/components/lov/lov.tsx` from string-based replace to regex with `g` flag:

- from: `.replace('%23', '#')`
- to: `.replace(/%23/g, '#')`

This preserves existing logic and behavior while removing the incomplete replacement issue. No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
