### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete string escaping or encoding

### DIFF
--- a/apps/frontend-nextjs/app/components/lov/lov.tsx
+++ b/apps/frontend-nextjs/app/components/lov/lov.tsx
@@ -116,7 +116,7 @@ const legalBasisLinkProcessor = (
       fn: (key: string, result: string[]) => (
         <Link
           key={key}
-          href={`${env.lovdataRettskildeBaseUrl.replace('%23', '#').replace(/\/#document.*/, '')}/#document/${result[2]}${result[3] ? '/' + result[3] : ''}`}
+          href={`${env.lovdataRettskildeBaseUrl.replace(/%23/g, '#').replace(/\/#document.*/, '')}/#document/${result[2]}${result[3] ? '/' + result[3] : ''}`}
           target={openOnSamePage ? '_self' : '_blank'}
           rel='noopener noreferrer'
         >


### PR DESCRIPTION
Potential fix for [https://github.com/navikt/etterlevelse/security/code-scanning/7](https://github.com/navikt/etterlevelse/security/code-scanning/7)

Use a global replacement for `%23` so all encoded hash markers are normalized, not only the first one.

Best fix in this file/region (line 119 area): change
- `replace('%23', '#')`
to
- `replace(/%23/g, '#')`

Keep the existing second replace (`.replace(/\/#document.*/, '')`) unchanged. This preserves functionality while removing the incomplete replacement issue.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
