### PR TITLE
Potential fix for code scanning alert no. 3: Overly permissive regular expression range

### DIFF
--- a/apps/frontend/src/components/Lov.tsx
+++ b/apps/frontend/src/components/Lov.tsx
@@ -121,7 +121,7 @@ const legalBasisLinkProcessor = (
       ),
     },
     {
-      regex: /(.*) art(ikkel)?\s*(\d+) ?([aA-zZ]?)( *\([0-9]*\))*/gi,
+      regex: /(.*) art(ikkel)?\s*(\d+) ?([A-Za-z]?)( *\([0-9]*\))*/gi,
       fn: (key: string, result: string[]) => (
         <Link
           key={key}


### PR DESCRIPTION
Potential fix for [https://github.com/navikt/etterlevelse/security/code-scanning/3](https://github.com/navikt/etterlevelse/security/code-scanning/3)

Use an explicit uppercase/lowercase letter range instead of `A-z`.  
Best fix without changing behavior: replace `([aA-zZ]?)` with `([A-Za-z]?)` in the affected regex on line 124 in `apps/frontend/src/components/Lov.tsx`. This preserves intent (optional one-letter suffix, case-insensitive-friendly) while removing unintended ASCII punctuation matches. No imports, new methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
