### PR TITLE
Potential fix for code scanning alert no. 1: Overly permissive regular expression range

### DIFF
--- a/apps/frontend/src/components/Lov.tsx
+++ b/apps/frontend/src/components/Lov.tsx
@@ -93,7 +93,7 @@ const legalBasisLinkProcessor = (
     },
     {
       // triple '§§§' is hidden, used as a trick in combination with rule 1 above
-      regex: /(.*) §(§§)?(§)?\s*(\d+(-\d+)?) ?([aA-zZ]?)( *\([0-9]*\))*/g,
+      regex: /(.*) §(§§)?(§)?\s*(\d+(-\d+)?) ?([A-Za-z]?)( *\([0-9]*\))*/g,
       fn: (key: string, result: string[]) => (
         <Link
           key={key}
@@ -107,7 +107,7 @@ const legalBasisLinkProcessor = (
       ),
     },
     {
-      regex: /(.*) kap(ittel)?\s*(\d+) ?([aA-zZ]?)( *\([0-9]*\))*/gi,
+      regex: /(.*) kap(ittel)?\s*(\d+) ?([A-Za-z]?)( *\([0-9]*\))*/gi,
       fn: (key: string, result: string[]) => (
         <Link
           key={key}
@@ -121,7 +121,7 @@ const legalBasisLinkProcessor = (
       ),
     },
     {
-      regex: /(.*) art(ikkel)?\s*(\d+) ?([aA-zZ]?)( *\([0-9]*\))*/gi,
+      regex: /(.*) art(ikkel)?\s*(\d+) ?([A-Za-z]?)( *\([0-9]*\))*/gi,
       fn: (key: string, result: string[]) => (
         <Link
           key={key}


### PR DESCRIPTION
Potential fix for [https://github.com/navikt/etterlevelse/security/code-scanning/1](https://github.com/navikt/etterlevelse/security/code-scanning/1)

Use explicit, unambiguous character classes for optional letter suffixes.

Best fix without changing intended functionality:
- In `apps/frontend/src/components/Lov.tsx`, replace every `([aA-zZ]?)` style class with `([A-Za-z]?)` (or equivalently `[a-zA-Z]?`).
- This preserves support for both uppercase and lowercase letters while excluding punctuation accidentally included by `A-z`.
- No new imports, helper methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
