### PR TITLE
feat(dashboard/tema): add per-tema etterlevelsesdokument count

### DIFF
--- a/apps/backend/src/main/java/no/nav/data/etterlevelse/dashboard/DashboardService.java
+++ b/apps/backend/src/main/java/no/nav/data/etterlevelse/dashboard/DashboardService.java
@@ -550,7 +550,7 @@ public class DashboardService {
         }
 
         Map<String, TemaDashboardResponse> statsMap = new LinkedHashMap<>();
-        Map<String, Set<java.util.UUID>> dokIdsByTema = new HashMap<>();
+        Map<String, Set<UUID>> dokIdsByTema = new HashMap<>();
 
         for (var dok : doks) {
             List<Krav> kravForEdok = new ArrayList<>(aktivKrav.stream().filter(k ->
@@ -615,8 +615,8 @@ public class DashboardService {
         }
 
         statsMap.forEach((temaCode, stats) -> {
-            var dokIds2 = dokIdsByTema.getOrDefault(temaCode, Set.of());
-            stats.setEtterlevelseDokumentCount(dokIds2.size());
+            var dokIdsForTema = dokIdsByTema.getOrDefault(temaCode, Set.of());
+            stats.setEtterlevelseDokumentCount(dokIdsForTema.size());
         });
 
         return statsMap.values().stream()

--- a/apps/backend/src/main/java/no/nav/data/etterlevelse/dashboard/DashboardService.java
+++ b/apps/backend/src/main/java/no/nav/data/etterlevelse/dashboard/DashboardService.java
@@ -549,6 +549,7 @@ public class DashboardService {
         }
 
         Map<String, TemaDashboardResponse> statsMap = new LinkedHashMap<>();
+        Map<String, Set<java.util.UUID>> dokIdsByTema = new HashMap<>();
 
         for (var dok : doks) {
             List<Krav> kravForEdok = new ArrayList<>(aktivKrav.stream().filter(k ->
@@ -580,6 +581,8 @@ public class DashboardService {
                     return TemaDashboardResponse.builder().temaCode(tc).temaName(temaName).build();
                 });
 
+                dokIdsByTema.computeIfAbsent(temaCode, k -> new HashSet<>()).add(dok.getId());
+
                 boolean isFerdig = etterlevelse.getStatus() == EtterlevelseStatus.FERDIG_DOKUMENTERT
                         || etterlevelse.getStatus() == EtterlevelseStatus.IKKE_RELEVANT_FERDIG_DOKUMENTERT;
 
@@ -609,6 +612,11 @@ public class DashboardService {
                 }
             }
         }
+
+        statsMap.forEach((temaCode, stats) -> {
+            var dokIds2 = dokIdsByTema.getOrDefault(temaCode, Set.of());
+            stats.setEtterlevelseDokumentCount(dokIds2.size());
+        });
 
         return statsMap.values().stream()
                 .sorted(Comparator.comparing(TemaDashboardResponse::getTemaName))

--- a/apps/backend/src/main/java/no/nav/data/etterlevelse/dashboard/DashboardService.java
+++ b/apps/backend/src/main/java/no/nav/data/etterlevelse/dashboard/DashboardService.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 

--- a/apps/backend/src/main/java/no/nav/data/etterlevelse/dashboard/dto/TemaDashboardResponse.java
+++ b/apps/backend/src/main/java/no/nav/data/etterlevelse/dashboard/dto/TemaDashboardResponse.java
@@ -25,4 +25,6 @@ public class TemaDashboardResponse {
     private int ferdigUtfyltKravSuksesskriterierIkkeOppfylt;
     private int ferdigUtfyltKravSuksesskriterierIkkeRelevant;
 
+    private int etterlevelseDokumentCount;
+
 }

--- a/apps/frontend-nextjs/app/components/dashboard/TemaDashboardPage.tsx
+++ b/apps/frontend-nextjs/app/components/dashboard/TemaDashboardPage.tsx
@@ -126,6 +126,12 @@ const RechartsStackedBar = ({
   )
 }
 
+const TemaDokumentCount = ({ count }: { count?: number }) => (
+  <Detail uppercase className='mt-2'>
+    {(count ?? 0).toLocaleString('nb-NO')} ETTERLEVELSESDOKUMENTER
+  </Detail>
+)
+
 const TemaStatsCard = ({ stats }: { stats: ITemaDashboardStats }) => {
   const kravData: IBarSegment[] = [
     { name: 'Under arbeid', value: stats.kravUnderArbeid, color: KRAV_COLORS.underArbeid },
@@ -215,9 +221,7 @@ const TemaStatsCard = ({ stats }: { stats: ITemaDashboardStats }) => {
         {stats.temaName}
       </Heading>
 
-      <Detail uppercase className='mt-2'>
-        {(stats.etterlevelseDokumentCount ?? 0).toLocaleString('nb-NO')} ETTERLEVELSESDOKUMENTER
-      </Detail>
+      <TemaDokumentCount count={stats.etterlevelseDokumentCount} />
 
       <div
         style={{
@@ -287,9 +291,7 @@ const TemaStatsKeyMetrics = ({ stats }: { stats: ITemaDashboardStats }) => {
         {stats.temaName}
       </Heading>
 
-      <Detail uppercase className='mt-2'>
-        {(stats.etterlevelseDokumentCount ?? 0).toLocaleString('nb-NO')} ETTERLEVELSESDOKUMENTER
-      </Detail>
+      <TemaDokumentCount count={stats.etterlevelseDokumentCount} />
 
       <div
         style={{

--- a/apps/frontend-nextjs/app/components/dashboard/TemaDashboardPage.tsx
+++ b/apps/frontend-nextjs/app/components/dashboard/TemaDashboardPage.tsx
@@ -13,7 +13,7 @@ import {
   ITemaDashboardStats,
 } from '@/constants/dashboard/dashboardConstants'
 import { DownloadIcon } from '@navikt/aksel-icons'
-import { BodyShort, Button, Heading, LocalAlert, Select, Tabs } from '@navikt/ds-react'
+import { BodyShort, Button, Detail, Heading, LocalAlert, Select, Tabs } from '@navikt/ds-react'
 import { useEffect, useState } from 'react'
 import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
 
@@ -215,6 +215,10 @@ const TemaStatsCard = ({ stats }: { stats: ITemaDashboardStats }) => {
         {stats.temaName}
       </Heading>
 
+      <Detail uppercase className='mt-2'>
+        {(stats.etterlevelseDokumentCount ?? 0).toLocaleString('nb-NO')} ETTERLEVELSESDOKUMENTER
+      </Detail>
+
       <div
         style={{
           display: 'grid',
@@ -282,6 +286,10 @@ const TemaStatsKeyMetrics = ({ stats }: { stats: ITemaDashboardStats }) => {
       <Heading size='small' level='2'>
         {stats.temaName}
       </Heading>
+
+      <Detail uppercase className='mt-2'>
+        {(stats.etterlevelseDokumentCount ?? 0).toLocaleString('nb-NO')} ETTERLEVELSESDOKUMENTER
+      </Detail>
 
       <div
         style={{

--- a/apps/frontend-nextjs/app/constants/dashboard/dashboardConstants.ts
+++ b/apps/frontend-nextjs/app/constants/dashboard/dashboardConstants.ts
@@ -45,6 +45,7 @@ export interface ITemaDashboardStats {
   ferdigUtfyltKravSuksesskriterierOppfylt?: number
   ferdigUtfyltKravSuksesskriterierIkkeOppfylt?: number
   ferdigUtfyltKravSuksesskriterierIkkeRelevant?: number
+  etterlevelseDokumentCount?: number
 }
 
 export interface IAvdelingDetailData {


### PR DESCRIPTION
- Add etterlevelseDokumentCount field to TemaDashboardResponse
- Track unique doc IDs per tema in DashboardService
- Display count as Detail uppercase on each tema card
- Count updates automatically when filtering by avdeling/seksjon