### PR TITLE
feat: add bulk export endpoint for latest etterlevelse dokumentasjoner

### DIFF
--- a/apps/backend/src/main/java/no/nav/data/etterlevelse/etterlevelseDokumentasjon/EtterlevelseDokumentasjonService.java
+++ b/apps/backend/src/main/java/no/nav/data/etterlevelse/etterlevelseDokumentasjon/EtterlevelseDokumentasjonService.java
@@ -43,7 +43,6 @@ import no.nav.data.integration.behandling.BehandlingService;
 import no.nav.data.integration.behandling.dto.Behandling;
 import no.nav.data.integration.dpBehandling.DpBehandlingService;
 import no.nav.data.integration.dpBehandling.dto.DpBehandling;
-import no.nav.data.integration.p360.P360ArkiveringService;
 import no.nav.data.integration.team.domain.Member;
 import no.nav.data.integration.team.domain.Team;
 import no.nav.data.integration.team.dto.Resource;
@@ -99,6 +98,10 @@ public class EtterlevelseDokumentasjonService {
 
     public List<EtterlevelseDokumentasjon> getEtterlevelseDokumentasjonerByTeam(String teamId) {
         return etterlevelseDokumentasjonRepoCustom.getEtterlevelseDokumentasjonerForTeam(List.of(teamId));
+    }
+
+    public List<EtterlevelseDokumentasjon> getLatestCreated(int limit) {
+        return etterlevelseDokumentasjonRepo.findLatestCreated(limit);
     }
 
     public List<EtterlevelseDokumentasjon> searchEtterlevelseDokumentasjon(String searchParam) {

--- a/apps/backend/src/main/java/no/nav/data/etterlevelse/etterlevelseDokumentasjon/domain/EtterlevelseDokumentasjonRepo.java
+++ b/apps/backend/src/main/java/no/nav/data/etterlevelse/etterlevelseDokumentasjon/domain/EtterlevelseDokumentasjonRepo.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import no.nav.data.etterlevelse.common.domain.KravId;
 
@@ -37,5 +38,8 @@ public interface EtterlevelseDokumentasjonRepo extends JpaRepository<Etterlevels
             countQuery = "select count(1) from etterlevelse_dokumentasjon where data->> 'title' not ilike '%fant ikke behandling%' and data->'behandlingIds' != '[]'",
             nativeQuery = true)
     Page<EtterlevelseDokumentasjon> getAllEtterlevelseDokumentasjonWithValidBehandling(Pageable pageable);
+
+    @Query(value = "select * from etterlevelse_dokumentasjon order by created_date desc limit :limit", nativeQuery = true)
+    List<EtterlevelseDokumentasjon> findLatestCreated(@Param("limit") int limit);
 
 }

--- a/apps/backend/src/main/java/no/nav/data/etterlevelse/export/ExportController.java
+++ b/apps/backend/src/main/java/no/nav/data/etterlevelse/export/ExportController.java
@@ -1,5 +1,23 @@
 package no.nav.data.etterlevelse.export;
 
+import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StreamUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -20,16 +38,6 @@ import no.nav.data.etterlevelse.etterlevelseDokumentasjon.EtterlevelseDokumentas
 import no.nav.data.etterlevelse.etterlevelseDokumentasjon.domain.EtterlevelseDokumentasjon;
 import no.nav.data.etterlevelse.krav.KravService;
 import no.nav.data.etterlevelse.krav.domain.Krav;
-import org.springframework.http.HttpHeaders;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StreamUtils;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.text.SimpleDateFormat;
-import java.util.*;
 
 @Slf4j
 @RestController
@@ -241,6 +249,86 @@ public class ExportController {
         response.flushBuffer();
     }
 
+
+    @Operation(summary = "Bulk export of the latest etterlevelse dokumentasjoner, without team, person, and risikoeier data")
+    @Transactional(readOnly = true)
+    @SneakyThrows
+    @GetMapping(value = "/etterlevelsedokumentasjon/bulk")
+    public void getBulkEtterlevelseDokumentasjon(
+            HttpServletResponse response,
+            @RequestParam(name = "limit", defaultValue = "100") int limit,
+            @RequestParam(name = "format", defaultValue = "json") String format
+    ) {
+        log.info("Bulk exporting {} latest etterlevelse dokumentasjoner, format={}", limit, format);
+        var documents = etterlevelseDokumentasjonService.getLatestCreated(limit);
+
+        if ("csv".equalsIgnoreCase(format)) {
+            response.setContentType("text/csv;charset=UTF-8");
+            response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=etterlevelse_bulk_export.csv");
+            var csv = new StringBuilder();
+            csv.append("id,etterlevelseNummer,title,status,etterlevelseDokumentVersjon,behandlingIds,dpBehandlingIds,nomAvdelingId,avdelingNavn,beskrivelse,createdDate,lastModifiedDate\n");
+            for (var doc : documents) {
+                var data = doc.getEtterlevelseDokumentasjonData();
+                csv.append(escapeCsv(doc.getId().toString())).append(",")
+                   .append(escapeCsv(String.valueOf(data.getEtterlevelseNummer()))).append(",")
+                   .append(escapeCsv(data.getTitle())).append(",")
+                   .append(escapeCsv(data.getStatus() != null ? data.getStatus().name() : "")).append(",")
+                   .append(escapeCsv(String.valueOf(data.getEtterlevelseDokumentVersjon()))).append(",")
+                   .append(escapeCsv(data.getBehandlingIds() != null ? String.join(";", data.getBehandlingIds()) : "")).append(",")
+                   .append(escapeCsv(data.getDpBehandlingIds() != null ? String.join(";", data.getDpBehandlingIds()) : "")).append(",")
+                   .append(escapeCsv(data.getNomAvdelingId() != null ? data.getNomAvdelingId() : "")).append(",")
+                   .append(escapeCsv(data.getAvdelingNavn() != null ? data.getAvdelingNavn() : "")).append(",")
+                   .append(escapeCsv(data.getBeskrivelse())).append(",")
+                   .append(escapeCsv(doc.getCreatedDate() != null ? doc.getCreatedDate().toString() : "")).append(",")
+                   .append(escapeCsv(doc.getLastModifiedDate() != null ? doc.getLastModifiedDate().toString() : "")).append("\n");
+            }
+            StreamUtils.copy(csv.toString().getBytes(StandardCharsets.UTF_8), response.getOutputStream());
+        } else {
+            response.setContentType("application/json;charset=UTF-8");
+            var rows = documents.stream().map(doc -> {
+                var data = doc.getEtterlevelseDokumentasjonData();
+                return new BulkExportRow(
+                        doc.getId().toString(),
+                        data.getEtterlevelseNummer(),
+                        data.getTitle(),
+                        data.getStatus() != null ? data.getStatus().name() : null,
+                        data.getEtterlevelseDokumentVersjon(),
+                        data.getBehandlingIds(),
+                        data.getDpBehandlingIds(),
+                        data.getNomAvdelingId(),
+                        data.getAvdelingNavn(),
+                        data.getBeskrivelse(),
+                        doc.getCreatedDate() != null ? doc.getCreatedDate().toString() : null,
+                        doc.getLastModifiedDate() != null ? doc.getLastModifiedDate().toString() : null
+                );
+            }).toList();
+            new ObjectMapper().writeValue(response.getOutputStream(), rows);
+        }
+        response.flushBuffer();
+    }
+
+    private String escapeCsv(String value) {
+        if (value == null) return "";
+        if (value.contains(",") || value.contains("\"") || value.contains("\n")) {
+            return "\"" + value.replace("\"", "\"\"") + "\"";
+        }
+        return value;
+    }
+
+    record BulkExportRow(
+            String id,
+            Integer etterlevelseNummer,
+            String title,
+            String status,
+            Integer etterlevelseDokumentVersjon,
+            List<String> behandlingIds,
+            List<String> dpBehandlingIds,
+            String nomAvdelingId,
+            String avdelingNavn,
+            String beskrivelse,
+            String createdDate,
+            String lastModifiedDate
+    ) {}
 
     private String cleanCodelistName(ListName listName) {
         return switch (listName) {


### PR DESCRIPTION
GET /export/etterlevelsedokumentasjon/bulk?limit=100&format=json|csv

Returns the N most recently created documents ordered by created_date DESC, excluding team, person, risikoeier and ansvarlig data.