### PR TITLE
feat(dashboard): add "Ikke påbegynt" to krav assessment status charts

### DIFF
--- a/apps/backend/src/main/java/no/nav/data/etterlevelse/dashboard/DashboardService.java
+++ b/apps/backend/src/main/java/no/nav/data/etterlevelse/dashboard/DashboardService.java
@@ -606,6 +606,31 @@ public class DashboardService {
             kravForEdok.forEach(k -> gyldigeKravKeys.add(k.getKravNummer() + "_" + k.getKravVersjon()));
             etterlevelserNotInKravForEdok.forEach(e -> gyldigeKravKeys.add(e.getKravNummer() + "_" + e.getKravVersjon()));
 
+            var existingEtterlevelseKeys = new HashSet<String>();
+            for (var etterlevelse : etterlevelseList) {
+                String key = etterlevelse.getKravNummer() + "_" + etterlevelse.getKravVersjon();
+                if (gyldigeKravKeys.contains(key)) {
+                    existingEtterlevelseKeys.add(key);
+                }
+            }
+
+            for (var krav : kravForEdok) {
+                String key = krav.getKravNummer() + "_" + krav.getKravVersjon();
+                if (!existingEtterlevelseKeys.contains(key)) {
+                    String temaCode = temaByKravKey.getOrDefault(key, "UTEN_TEMA");
+                    var stats = statsMap.computeIfAbsent(temaCode, tc -> {
+                        if ("UTEN_TEMA".equals(tc)) {
+                            return TemaDashboardResponse.builder().temaCode(tc).temaName("Uten tema").build();
+                        }
+                        var temaData = CodelistService.getCodelist(ListName.TEMA, tc);
+                        String temaName = temaData != null ? temaData.getShortName() : tc;
+                        return TemaDashboardResponse.builder().temaCode(tc).temaName(temaName).build();
+                    });
+                    stats.setKravIkkePaabegynt(stats.getKravIkkePaabegynt() + 1);
+                    dokIdsByTema.computeIfAbsent(temaCode, k -> new HashSet<>()).add(dok.getId());
+                }
+            }
+
             for (var etterlevelse : etterlevelseList) {
                 String kravKey = etterlevelse.getKravNummer() + "_" + etterlevelse.getKravVersjon();
 
@@ -763,13 +788,13 @@ public class DashboardService {
                 }
         );
 
-        createKravDashboardCount(aktivKravList, kravDashboardStats, alleEtterlevelse);
-        createKravDashboardCount(utgaatKravUtenNyVersjon, kravDashboardStats, alleEtterlevelse);
+        createKravDashboardCount(aktivKravList, kravDashboardStats, alleEtterlevelse, doks);
+        createKravDashboardCount(utgaatKravUtenNyVersjon, kravDashboardStats, alleEtterlevelse, doks);
 
        return kravDashboardStats;
     }
 
-    private void createKravDashboardCount (List<Krav> kravList, List<KravDashboardResponse> kravDashboardStats, List<Etterlevelse> alleEtterlevelse) {
+    private void createKravDashboardCount (List<Krav> kravList, List<KravDashboardResponse> kravDashboardStats, List<Etterlevelse> alleEtterlevelse, List<EtterlevelseDokumentasjon> doks) {
         kravList.forEach(krav -> {
             KravDashboardResponse kravDashboardResponse = KravDashboardResponse.builder()
                     .kravId(krav.getId())
@@ -779,17 +804,32 @@ public class DashboardService {
                     .kravNavn(krav.getNavn())
                     .build();
 
-            getKravStats(kravDashboardResponse, alleEtterlevelse);
+            getKravStats(kravDashboardResponse, krav, alleEtterlevelse, doks);
 
             kravDashboardStats.add(kravDashboardResponse);
         });
     }
 
-    private void getKravStats (KravDashboardResponse kravDashboardResponse, List<Etterlevelse> alleEtterlevelse) {
+    private void getKravStats (KravDashboardResponse kravDashboardResponse, Krav krav, List<Etterlevelse> alleEtterlevelse, List<EtterlevelseDokumentasjon> doks) {
         var etterlevelseList = alleEtterlevelse.stream().filter(e ->
                 e.getKravNummer().equals(kravDashboardResponse.getKravNummer()) &&
                 e.getKravVersjon().equals(kravDashboardResponse.getKravVersjon())
         ).toList();
+
+        var dokIdsWithEtterlevelse = etterlevelseList.stream()
+                .map(e -> e.getEtterlevelseDokumentasjonId())
+                .collect(Collectors.toSet());
+
+        long ikkePaabegynt = doks.stream()
+                .filter(dok -> {
+                    var irrelevans = dok.getIrrelevansFor();
+                    var relevansFor = krav.getRelevansFor();
+                    return relevansFor.isEmpty() || !new HashSet<>(irrelevans).containsAll(relevansFor);
+                })
+                .filter(dok -> !dokIdsWithEtterlevelse.contains(dok.getId()))
+                .count();
+
+        kravDashboardResponse.setAntallIkkePaabegynt((int) ikkePaabegynt);
 
         for (var etterlevelse : etterlevelseList) {
             boolean isFerdig = etterlevelse.getStatus() == EtterlevelseStatus.FERDIG_DOKUMENTERT

--- a/apps/backend/src/main/java/no/nav/data/etterlevelse/dashboard/dto/KravDashboardResponse.java
+++ b/apps/backend/src/main/java/no/nav/data/etterlevelse/dashboard/dto/KravDashboardResponse.java
@@ -20,6 +20,7 @@ public class KravDashboardResponse {
     private Integer kravVersjon;
 
     private int etterlevelseTotal;
+    private int antallIkkePaabegynt;
     private int antallUnderArbeid;
     private int antallFerdigVurdert;
     private int antallSuksesskriterierUnderArbeid;

--- a/apps/backend/src/main/java/no/nav/data/etterlevelse/dashboard/dto/TemaDashboardResponse.java
+++ b/apps/backend/src/main/java/no/nav/data/etterlevelse/dashboard/dto/TemaDashboardResponse.java
@@ -14,6 +14,7 @@ public class TemaDashboardResponse {
     private String temaCode;
     private String temaName;
     private int kravTotal;
+    private int kravIkkePaabegynt;
     private int kravUnderArbeid;
     private int kravFerdigVurdert;
     private int suksesskriterierUnderArbeid;

--- a/apps/frontend-nextjs/app/components/dashboard/TemaDashboardPage.tsx
+++ b/apps/frontend-nextjs/app/components/dashboard/TemaDashboardPage.tsx
@@ -46,6 +46,7 @@ const TemaDokumentCount = ({ count }: { count?: number }) => (
 
 const TemaStatsCard = ({ stats }: { stats: ITemaDashboardStats }) => {
   const kravData: IBarSegment[] = [
+    { name: 'Ikke påbegynt', value: stats.kravIkkePaabegynt, color: SUKSESS_COLORS.ikkePaabegynt },
     { name: 'Under arbeid', value: stats.kravUnderArbeid, color: KRAV_COLORS.underArbeid },
     { name: 'Ferdig vurdert', value: stats.kravFerdigVurdert, color: KRAV_COLORS.ferdigVurdert },
   ]
@@ -212,19 +213,31 @@ const TemaStatsKeyMetrics = ({ stats }: { stats: ITemaDashboardStats }) => {
       <div className='grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-x-8 gap-y-4 mt-4'>
         <div>
           {(() => {
-            const kravPcts = roundedPercentages([stats.kravUnderArbeid, stats.kravFerdigVurdert])
+            const kravTotalWithIkkePaabegynt = stats.kravIkkePaabegynt + stats.kravTotal
+            const kravPcts = roundedPercentages([
+              stats.kravIkkePaabegynt,
+              stats.kravUnderArbeid,
+              stats.kravFerdigVurdert,
+            ])
             return (
               <>
                 <Heading size='xsmall' level='4' className='mb-2'>
-                  Gjennomføringsstatus: krav ({stats.kravTotal})
+                  Gjennomføringsstatus: krav ({kravTotalWithIkkePaabegynt})
                 </Heading>
                 <BodyShort>
+                  Ikke påbegynt <span className='font-bold'>{stats.kravIkkePaabegynt}</span>
+                  {kravTotalWithIkkePaabegynt > 0 &&
+                    ` (${formatPct(kravPcts[0], stats.kravIkkePaabegynt)}%)`}
+                </BodyShort>
+                <BodyShort>
                   Under arbeid <span className='font-bold'>{stats.kravUnderArbeid}</span>
-                  {stats.kravTotal > 0 && ` (${formatPct(kravPcts[0], stats.kravUnderArbeid)}%)`}
+                  {kravTotalWithIkkePaabegynt > 0 &&
+                    ` (${formatPct(kravPcts[1], stats.kravUnderArbeid)}%)`}
                 </BodyShort>
                 <BodyShort>
                   Ferdig vurdert <span className='font-bold'>{stats.kravFerdigVurdert}</span>
-                  {stats.kravTotal > 0 && ` (${formatPct(kravPcts[1], stats.kravFerdigVurdert)}%)`}
+                  {kravTotalWithIkkePaabegynt > 0 &&
+                    ` (${formatPct(kravPcts[2], stats.kravFerdigVurdert)}%)`}
                 </BodyShort>
               </>
             )

--- a/apps/frontend-nextjs/app/components/dashboard/TemaDetailPage.tsx
+++ b/apps/frontend-nextjs/app/components/dashboard/TemaDetailPage.tsx
@@ -45,6 +45,7 @@ interface IProps {
 
 const KravStatsCard = ({ krav }: { krav: IKravDashboardStats }) => {
   const kravData: IBarSegment[] = [
+    { name: 'Ikke påbegynt', value: krav.antallIkkePaabegynt, color: SUKSESS_COLORS.ikkePaabegynt },
     { name: 'Under arbeid', value: krav.antallUnderArbeid, color: KRAV_COLORS.underArbeid },
     { name: 'Ferdig vurdert', value: krav.antallFerdigVurdert, color: KRAV_COLORS.ferdigVurdert },
   ]
@@ -203,6 +204,7 @@ const exportKravToCsv = (
     'Kravnavn',
     'Status',
     'Antall etterlevelser totalt',
+    'Etterlevelser ikke påbegynt',
     'Etterlevelser under arbeid',
     'Etterlevelser ferdig vurdert',
     'Alle suksesskriterier - ikke påbegynt',
@@ -233,6 +235,7 @@ const exportKravToCsv = (
       escapeCsvField(`K${k.kravNummer} ${k.kravNavn}`),
       escapeCsvField(k.kravStatus),
       k.etterlevelseTotal,
+      k.antallIkkePaabegynt,
       k.antallUnderArbeid,
       k.antallFerdigVurdert,
       k.antallSuksesskriterierIkkePaabegynt,
@@ -422,6 +425,11 @@ const TemaDetailPage = ({ temaCode }: IProps) => {
 
   const kravData: IBarSegment[] = temaStats
     ? [
+        {
+          name: 'Ikke påbegynt',
+          value: temaStats.kravIkkePaabegynt,
+          color: SUKSESS_COLORS.ikkePaabegynt,
+        },
         { name: 'Under arbeid', value: temaStats.kravUnderArbeid, color: KRAV_COLORS.underArbeid },
         {
           name: 'Ferdig vurdert',
@@ -631,6 +639,7 @@ const TemaDetailPage = ({ temaCode }: IProps) => {
               ]
               const header = [
                 'Krav totalt',
+                'Krav ikke påbegynt',
                 'Krav under arbeid',
                 'Krav ferdig vurdert',
                 'Suksesskriterier ikke påbegynt',
@@ -648,7 +657,8 @@ const TemaDetailPage = ({ temaCode }: IProps) => {
                 'Ikke ferdig utfylt krav - suksesskriterier ikke relevant',
               ].join(';')
               const row = [
-                temaStats.kravTotal,
+                temaStats.kravIkkePaabegynt + temaStats.kravTotal,
+                temaStats.kravIkkePaabegynt,
                 temaStats.kravUnderArbeid,
                 temaStats.kravFerdigVurdert,
                 temaStats.suksesskriterierIkkePaabegynt,
@@ -740,26 +750,35 @@ const TemaDetailPage = ({ temaCode }: IProps) => {
                 <div className='grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-x-8 gap-y-4'>
                   <div>
                     {(() => {
+                      const kravTotalWithIkkePaabegynt =
+                        temaStats.kravIkkePaabegynt + temaStats.kravTotal
                       const kravPcts = roundedPercentages([
+                        temaStats.kravIkkePaabegynt,
                         temaStats.kravUnderArbeid,
                         temaStats.kravFerdigVurdert,
                       ])
                       return (
                         <>
                           <Heading size='xsmall' level='3' className='mb-2'>
-                            Gjennomføringsstatus: krav ({temaStats.kravTotal})
+                            Gjennomføringsstatus: krav ({kravTotalWithIkkePaabegynt})
                           </Heading>
+                          <BodyShort>
+                            Ikke påbegynt{' '}
+                            <span className='font-bold'>{temaStats.kravIkkePaabegynt}</span>
+                            {kravTotalWithIkkePaabegynt > 0 &&
+                              ` (${formatPct(kravPcts[0], temaStats.kravIkkePaabegynt)}%)`}
+                          </BodyShort>
                           <BodyShort>
                             Under arbeid{' '}
                             <span className='font-bold'>{temaStats.kravUnderArbeid}</span>
-                            {temaStats.kravTotal > 0 &&
-                              ` (${formatPct(kravPcts[0], temaStats.kravUnderArbeid)}%)`}
+                            {kravTotalWithIkkePaabegynt > 0 &&
+                              ` (${formatPct(kravPcts[1], temaStats.kravUnderArbeid)}%)`}
                           </BodyShort>
                           <BodyShort>
                             Ferdig vurdert{' '}
                             <span className='font-bold'>{temaStats.kravFerdigVurdert}</span>
-                            {temaStats.kravTotal > 0 &&
-                              ` (${formatPct(kravPcts[1], temaStats.kravFerdigVurdert)}%)`}
+                            {kravTotalWithIkkePaabegynt > 0 &&
+                              ` (${formatPct(kravPcts[2], temaStats.kravFerdigVurdert)}%)`}
                           </BodyShort>
                         </>
                       )
@@ -1090,8 +1109,10 @@ const TemaDetailPage = ({ temaCode }: IProps) => {
             <Tabs.Panel value='nokkeltall'>
               <div className='flex flex-col gap-6 mt-6'>
                 {sortedKrav.map((krav) => {
-                  const kravTotal = krav.antallUnderArbeid + krav.antallFerdigVurdert
+                  const kravTotal =
+                    krav.antallIkkePaabegynt + krav.antallUnderArbeid + krav.antallFerdigVurdert
                   const kravPcts = roundedPercentages([
+                    krav.antallIkkePaabegynt,
                     krav.antallUnderArbeid,
                     krav.antallFerdigVurdert,
                   ])
@@ -1168,15 +1189,21 @@ const TemaDetailPage = ({ temaCode }: IProps) => {
                             Gjennomføringsstatus: krav ({kravTotal})
                           </Heading>
                           <BodyShort>
+                            Ikke påbegynt{' '}
+                            <span className='font-bold'>{krav.antallIkkePaabegynt}</span>
+                            {kravTotal > 0 &&
+                              ` (${formatPct(kravPcts[0], krav.antallIkkePaabegynt)}%)`}
+                          </BodyShort>
+                          <BodyShort>
                             Under arbeid <span className='font-bold'>{krav.antallUnderArbeid}</span>
                             {kravTotal > 0 &&
-                              ` (${formatPct(kravPcts[0], krav.antallUnderArbeid)}%)`}
+                              ` (${formatPct(kravPcts[1], krav.antallUnderArbeid)}%)`}
                           </BodyShort>
                           <BodyShort>
                             Ferdig vurdert{' '}
                             <span className='font-bold'>{krav.antallFerdigVurdert}</span>
                             {kravTotal > 0 &&
-                              ` (${formatPct(kravPcts[1], krav.antallFerdigVurdert)}%)`}
+                              ` (${formatPct(kravPcts[2], krav.antallFerdigVurdert)}%)`}
                           </BodyShort>
                         </div>
                         <div>

--- a/apps/frontend-nextjs/app/constants/dashboard/dashboardConstants.ts
+++ b/apps/frontend-nextjs/app/constants/dashboard/dashboardConstants.ts
@@ -37,6 +37,7 @@ export interface ITemaDashboardStats {
   temaCode: string
   temaName: string
   kravTotal: number
+  kravIkkePaabegynt: number
   kravUnderArbeid: number
   kravFerdigVurdert: number
   suksesskriterierUnderArbeid: number
@@ -57,6 +58,7 @@ export interface IKravDashboardStats {
   kravNummer: number
   kravVersjon: number
   etterlevelseTotal: number
+  antallIkkePaabegynt: number
   antallUnderArbeid: number
   antallFerdigVurdert: number
   antallSuksesskriterierUnderArbeid: number


### PR DESCRIPTION
Show doc/krav combinations where assessment has not been started yet, making the full picture visible instead of only counting existing etterlevelse records.

- Add kravIkkePaabegynt to TemaDashboardResponse (tema-level count)
- Add antallIkkePaabegynt to KravDashboardResponse (krav-level count)
- Compute tema-level count by finding kravForEdok entries with no matching etterlevelse record per doc
- Compute krav-level count using relevance-aware doc filtering (respects irrelevansFor, only counts docs where krav is applicable)
- Update frontend charts, nøkkeltall sections and CSV exports to include "Ikke påbegynt" with the same purple color (#8a3ffc) as used in the suksesskriterier chart