### PR TITLE
fix(pvk): exclude iverksatte tiltak from "uten frist" filter and alig…

### DIFF
--- a/apps/frontend-nextjs/app/components/PVK/pvkDokumentPage/stepperViews/oppsummeringAvAlleRisikoscenarioerOgTiltak/oppsummeringAvAlleRisikoscenarioerOgTiltak.tsx
+++ b/apps/frontend-nextjs/app/components/PVK/pvkDokumentPage/stepperViews/oppsummeringAvAlleRisikoscenarioerOgTiltak/oppsummeringAvAlleRisikoscenarioerOgTiltak.tsx
@@ -18,7 +18,11 @@ import {
   ERisikoscenarioType,
   IRisikoscenario,
 } from '@/constants/etterlevelseDokumentasjon/personvernkonsekvensevurdering/risikoscenario/risikoscenarioConstants'
-import { ITiltak } from '@/constants/etterlevelseDokumentasjon/personvernkonsekvensevurdering/tiltak/tiltakConstants'
+import {
+  ITiltak,
+  filterTiltakList,
+  tiltakFilterValues,
+} from '@/constants/etterlevelseDokumentasjon/personvernkonsekvensevurdering/tiltak/tiltakConstants'
 import {
   EPvoTilbakemeldingStatus,
   IPvoTilbakemelding,
@@ -63,12 +67,6 @@ export const filterValues = {
   effektIkkeVurdert: 'ikke-vurdert',
   hoyRisiko: 'hoy-risiko',
   tiltakIkkeAktuelt: 'ingen-tiltak',
-}
-
-export const tiltakFilterValues = {
-  alleTiltak: 'alleTiltak',
-  utenAnsvarlig: 'utenAnsvarlig',
-  utenFrist: 'utenFrist',
 }
 
 const visTomListeBeskrivelse = (filter: string | null) => {
@@ -315,22 +313,7 @@ export const OppsummeringAvAlleRisikoscenarioerOgTiltak: FunctionComponent<TProp
     setTiltakFilter(filter)
     const tab: string = tabQuery ? tabQuery : tabValues.tiltak
 
-    switch (filter) {
-      case tiltakFilterValues.alleTiltak:
-        setFilteredTiltakList(tiltakList)
-        break
-      case tiltakFilterValues.utenAnsvarlig:
-        setFilteredTiltakList(
-          tiltakList.filter(
-            (tiltak: ITiltak) =>
-              !tiltak.ansvarlig || (!tiltak.ansvarlig.navIdent && !tiltak.ansvarligTeam.name)
-          )
-        )
-        break
-      case tiltakFilterValues.utenFrist:
-        setFilteredTiltakList(tiltakList.filter((tiltak: ITiltak) => !tiltak.frist))
-        break
-    }
+    setFilteredTiltakList(filterTiltakList(tiltakList, filter))
 
     setNavigateUrl(pvkDokumentasjonTabFilterTiltakUrl(steg, tab, filter, tiltakId))
     if (formRef.current?.dirty) {
@@ -591,6 +574,7 @@ export const OppsummeringAvAlleRisikoscenarioerOgTiltak: FunctionComponent<TProp
                             setTiltakList={setTiltakList}
                             filteredTiltakList={filteredTiltakList}
                             setFilteredTiltakList={setFilteredTiltakList}
+                            tiltakFilter={tiltakFilter}
                             risikoscenarioList={risikoscenarioList}
                             formRef={formRef}
                           />

--- a/apps/frontend-nextjs/app/components/PVK/pvkDokumentPage/stepperViews/readOnlyViews/oppsummeringAvAlleRisikoscenarioerOgTiltak/oppsummeringAvAlleRisikoscenarioerOgTiltakReadOnlyView.tsx
+++ b/apps/frontend-nextjs/app/components/PVK/pvkDokumentPage/stepperViews/readOnlyViews/oppsummeringAvAlleRisikoscenarioerOgTiltak/oppsummeringAvAlleRisikoscenarioerOgTiltakReadOnlyView.tsx
@@ -299,7 +299,9 @@ export const OppsummeringAvAlleRisikoscenarioerOgTiltakReadOnlyView: FunctionCom
         )
         break
       case tiltakFilterValues.utenFrist:
-        setFilteredTiltakList(tiltakList.filter((tiltak: ITiltak) => !tiltak.frist))
+        setFilteredTiltakList(
+          tiltakList.filter((tiltak: ITiltak) => !tiltak.iverksatt && !tiltak.frist)
+        )
         break
     }
 

--- a/apps/frontend-nextjs/app/components/pvoTilbakemelding/pvoTilbakemeldingPage/stepperViews/oppsummeringAvAlleRisikoscenarioerOgTiltakPvoView.tsx
+++ b/apps/frontend-nextjs/app/components/pvoTilbakemelding/pvoTilbakemeldingPage/stepperViews/oppsummeringAvAlleRisikoscenarioerOgTiltakPvoView.tsx
@@ -175,10 +175,12 @@ export const OppsummeringAvAlleRisikoscenarioerOgTiltakPvoView: FunctionComponen
           setAntallUtenTiltakAnsvarlig(
             tiltak.content.filter(
               (tiltak: ITiltak) =>
-                !tiltak.ansvarlig || (tiltak.ansvarlig && tiltak.ansvarlig.navIdent === '')
+                !tiltak.ansvarlig || (!tiltak.ansvarlig.navIdent && !tiltak.ansvarligTeam.name)
             ).length
           )
-          setAntallUtenFrist(tiltak.content.filter((tiltak: ITiltak) => !tiltak.frist).length)
+          setAntallUtenFrist(
+            tiltak.content.filter((tiltak: ITiltak) => !tiltak.iverksatt && !tiltak.frist).length
+          )
         })
         setIsLoading(false)
       })()
@@ -268,12 +270,13 @@ export const OppsummeringAvAlleRisikoscenarioerOgTiltakPvoView: FunctionComponen
       case tiltakFilterValues.utenAnsvarlig:
         setFilteredTiltakList(
           tiltakList.filter(
-            (tiltak) => !tiltak.ansvarlig || (tiltak.ansvarlig && tiltak.ansvarlig.navIdent === '')
+            (tiltak) =>
+              !tiltak.ansvarlig || (!tiltak.ansvarlig.navIdent && !tiltak.ansvarligTeam.name)
           )
         )
         break
       case tiltakFilterValues.utenFrist:
-        setFilteredTiltakList(tiltakList.filter((tiltak) => !tiltak.frist))
+        setFilteredTiltakList(tiltakList.filter((tiltak) => !tiltak.iverksatt && !tiltak.frist))
         break
     }
   }

--- a/apps/frontend-nextjs/app/components/tiltak/common/tiltakAccordionList.tsx
+++ b/apps/frontend-nextjs/app/components/tiltak/common/tiltakAccordionList.tsx
@@ -9,7 +9,10 @@ import {
   IPvkDokument,
 } from '@/constants/etterlevelseDokumentasjon/personvernkonsekvensevurdering/personvernkonsekvensevurderingConstants'
 import { IRisikoscenario } from '@/constants/etterlevelseDokumentasjon/personvernkonsekvensevurdering/risikoscenario/risikoscenarioConstants'
-import { ITiltak } from '@/constants/etterlevelseDokumentasjon/personvernkonsekvensevurdering/tiltak/tiltakConstants'
+import {
+  ITiltak,
+  filterTiltakList,
+} from '@/constants/etterlevelseDokumentasjon/personvernkonsekvensevurdering/tiltak/tiltakConstants'
 import {
   pvkDokumentasjonTabFilterTiltakUrl,
   pvkDokumentasjonTabFilterUrl,
@@ -27,6 +30,7 @@ type TProps = {
   setTiltakList: (state: ITiltak[]) => void
   filteredTiltakList: ITiltak[]
   setFilteredTiltakList: (state: ITiltak[]) => void
+  tiltakFilter: string
   risikoscenarioList: IRisikoscenario[]
   formRef: RefObject<any>
 }
@@ -38,6 +42,7 @@ type TContentProps = {
   setTiltakList: (state: ITiltak[]) => void
   filteredTiltakList: ITiltak[]
   setFilteredTiltakList: (state: ITiltak[]) => void
+  tiltakFilter: string
   risikoscenarioList: IRisikoscenario[]
   formRef: RefObject<any>
 }
@@ -48,6 +53,7 @@ export const TiltakAccordionList: FunctionComponent<TProps> = ({
   setTiltakList,
   filteredTiltakList,
   setFilteredTiltakList,
+  tiltakFilter,
   risikoscenarioList,
   formRef,
 }) => {
@@ -139,6 +145,7 @@ export const TiltakAccordionList: FunctionComponent<TProps> = ({
                     filteredTiltakList={filteredTiltakList}
                     setTiltakList={setTiltakList}
                     setFilteredTiltakList={setFilteredTiltakList}
+                    tiltakFilter={tiltakFilter}
                     formRef={formRef}
                   />
                 </Accordion.Content>
@@ -164,8 +171,8 @@ export const TiltakAccordionContent: FunctionComponent<TContentProps> = ({
   risikoscenarioList,
   tiltakList,
   setTiltakList,
-  filteredTiltakList,
   setFilteredTiltakList,
+  tiltakFilter,
   formRef,
 }) => {
   const [isEditModalOpen, setIsEditModalOpen] = useState<boolean>(false)
@@ -174,24 +181,15 @@ export const TiltakAccordionContent: FunctionComponent<TContentProps> = ({
   const submit = async (submitedValues: ITiltak) => {
     await updateTiltak(submitedValues)
       .then((response) => {
-        setFilteredTiltakList(
-          filteredTiltakList.map((tiltak) => {
-            if (tiltak.id === response.id) {
-              return { ...response }
-            } else {
-              return tiltak
-            }
-          })
-        )
-        setTiltakList(
-          tiltakList.map((tiltak) => {
-            if (tiltak.id === response.id) {
-              return { ...response }
-            } else {
-              return tiltak
-            }
-          })
-        )
+        const updatedTiltakList: ITiltak[] = tiltakList.map((tiltak) => {
+          if (tiltak.id === response.id) {
+            return { ...response }
+          } else {
+            return tiltak
+          }
+        })
+        setTiltakList(updatedTiltakList)
+        setFilteredTiltakList(filterTiltakList(updatedTiltakList, tiltakFilter))
       })
       .finally(() => {
         setIsEditModalOpen(false)

--- a/apps/frontend-nextjs/app/constants/etterlevelseDokumentasjon/personvernkonsekvensevurdering/tiltak/tiltakConstants.ts
+++ b/apps/frontend-nextjs/app/constants/etterlevelseDokumentasjon/personvernkonsekvensevurdering/tiltak/tiltakConstants.ts
@@ -14,3 +14,23 @@ export interface ITiltak extends IDomainObject {
   iverksattDato?: string
   iverksettingsKommentar?: string
 }
+
+export const tiltakFilterValues = {
+  alleTiltak: 'alleTiltak',
+  utenAnsvarlig: 'utenAnsvarlig',
+  utenFrist: 'utenFrist',
+}
+
+export const filterTiltakList = (tiltakList: ITiltak[], filter: string): ITiltak[] => {
+  switch (filter) {
+    case tiltakFilterValues.utenAnsvarlig:
+      return tiltakList.filter(
+        (tiltak: ITiltak) =>
+          !tiltak.ansvarlig || (!tiltak.ansvarlig.navIdent && !tiltak.ansvarligTeam.name)
+      )
+    case tiltakFilterValues.utenFrist:
+      return tiltakList.filter((tiltak: ITiltak) => !tiltak.iverksatt && !tiltak.frist)
+    default:
+      return tiltakList
+  }
+}


### PR DESCRIPTION
…n PVO counts

- Exclude tiltak marked as iverksatt from the "uten frist" list/count
- Re-apply active tiltak filter after editing a tiltak so the list updates immediately (e.g. when marking as iverksatt) without a page refresh
- Align PVO view's "uten ansvarlig"/"uten frist" counts and filters with the read-only view so tab counts match the displayed list
- Extract shared tiltakFilterValues/filterTiltakList helpers to tiltakConstants.ts to avoid duplicated filter logic