### PR TITLE
feat(dashboard): add etterlevelsesdokumenter tab to tema detail page

### DIFF
--- a/apps/backend/src/main/java/no/nav/data/etterlevelse/dashboard/DashboardController.java
+++ b/apps/backend/src/main/java/no/nav/data/etterlevelse/dashboard/DashboardController.java
@@ -63,6 +63,23 @@ public class DashboardController {
         }
     }
 
+    @Operation(summary = "Get dashboard table for a single tema")
+    @ApiResponse(description = "ok")
+    @GetMapping("/table/tema/{temaCode}")
+    public ResponseEntity<List<DashboardTableResponse>> getTableDashboardForTema(
+            @PathVariable String temaCode,
+            @RequestParam(required = false) String avdelingId,
+            @RequestParam(required = false) String seksjonId,
+            @RequestParam(required = false) String enhetId,
+            @RequestParam(required = false) List<String> teamId) {
+        log.info("Getting dashboard table for tema={} avdelingId={} seksjonId={} enhetId={} teamId={}", temaCode, avdelingId, seksjonId, enhetId, teamId);
+        var tema = CodelistService.getCodelist(ListName.TEMA, temaCode);
+        if (tema == null) {
+            throw new ValidationException( "Invalid temaCode: " + temaCode);
+        }
+        return ResponseEntity.ok(dashboardService.getDashboardTableByTema(temaCode, avdelingId, seksjonId, enhetId, teamId));
+    }
+
     @Operation(summary = "Get tema dashboard stats")
     @ApiResponse(description = "ok")
     @GetMapping("/tema")

--- a/apps/backend/src/main/java/no/nav/data/etterlevelse/dashboard/DashboardService.java
+++ b/apps/backend/src/main/java/no/nav/data/etterlevelse/dashboard/DashboardService.java
@@ -92,8 +92,75 @@ public class DashboardService {
         List<EtterlevelseDokumentasjon> allEdoksWithAvdeling = etterlevelseDokumentasjonService.getByAvdeling(avdelingId);
         List<Krav> aktivKrav = kravService.getByFilter(KravFilter.builder().status(List.of(KravStatus.AKTIV.name())).build());
 
+        return buildDashboardTable(allEdoksWithAvdeling, aktivKrav);
+    }
+
+    public List<DashboardTableResponse> getDashboardTableByTema(String temaCode, String avdelingId, String seksjonId, String enhetId, List<String> teamIds) {
+        List<EtterlevelseDokumentasjon> doks;
+
+        if (avdelingId != null && !avdelingId.isEmpty()) {
+            String effectiveAvdelingId = "ingen-avdeling".equals(avdelingId) ? "" : avdelingId;
+            doks = etterlevelseDokumentasjonService.getByAvdeling(effectiveAvdelingId);
+
+            if (seksjonId != null && !seksjonId.isEmpty()) {
+                if (seksjonId.equals("ingen-seksjon")) {
+                    doks = doks.stream().filter(d ->
+                            d.getEtterlevelseDokumentasjonData().getSeksjoner() == null ||
+                            d.getEtterlevelseDokumentasjonData().getSeksjoner().isEmpty()
+                    ).toList();
+                } else {
+                    doks = doks.stream().filter(d ->
+                            d.getEtterlevelseDokumentasjonData().getSeksjoner() != null &&
+                            d.getEtterlevelseDokumentasjonData().getSeksjoner().stream()
+                                    .anyMatch(ns -> seksjonId.equals(ns.getNomSeksjonId()))
+                    ).toList();
+                }
+            }
+
+            if (enhetId != null && !enhetId.isEmpty()) {
+                if (enhetId.equals("ingen-enhet")) {
+                    doks = doks.stream().filter(d ->
+                            d.getEtterlevelseDokumentasjonData().getEnheter() == null ||
+                            d.getEtterlevelseDokumentasjonData().getEnheter().isEmpty()
+                    ).toList();
+                } else {
+                    doks = doks.stream().filter(d ->
+                            d.getEtterlevelseDokumentasjonData().getEnheter() != null &&
+                            d.getEtterlevelseDokumentasjonData().getEnheter().stream()
+                                    .anyMatch(ne -> enhetId.equals(ne.getNomEnhetId()))
+                    ).toList();
+                }
+            }
+        } else {
+            doks = etterlevelseDokumentasjonService.getAll(Pageable.unpaged()).getContent();
+        }
+
+        if (teamIds != null && !teamIds.isEmpty()) {
+            doks = doks.stream().filter(d ->
+                    d.getTeams() != null &&
+                    d.getTeams().stream().anyMatch(teamIds::contains)
+            ).toList();
+        }
+
+        List<Krav> aktivKrav;
+        if (temaCode != null && !temaCode.isEmpty()) {
+            var lovCodeForTema = CodelistService.getCodelist(ListName.LOV)
+                    .stream().filter(lov -> lov.getValueFromKeyData("tema").equals(temaCode))
+                    .map(Codelist::getCode).toList();
+
+            aktivKrav = kravService.getByFilter(KravFilter.builder().lover(lovCodeForTema).status(List.of(KravStatus.AKTIV.name())).build());
+        } else {
+            aktivKrav = kravService.getByFilter(KravFilter.builder().status(List.of(KravStatus.AKTIV.name())).build());
+        }
+
+        return buildDashboardTable(doks, aktivKrav).stream()
+                .filter(r -> r.getAntallKrav() != null && r.getAntallKrav() > 0)
+                .toList();
+    }
+
+    private List<DashboardTableResponse> buildDashboardTable(List<EtterlevelseDokumentasjon> doks, List<Krav> aktivKrav) {
         LocalDate now = LocalDate.now();
-        return allEdoksWithAvdeling.stream()
+        return doks.stream()
                 .map(dok -> {
                     List<Etterlevelse> etterlevelserForDok = etterlevelseService.getByEtterlevelseDokumentasjon(dok.getId());
                     List<Krav> kravForEdok = new ArrayList<>(aktivKrav.stream().filter(k ->

--- a/apps/frontend-nextjs/app/api/dashboard/dashboardApi.ts
+++ b/apps/frontend-nextjs/app/api/dashboard/dashboardApi.ts
@@ -24,6 +24,25 @@ export const getDashboardTableByAvdeling = async (
   return response.data
 }
 
+export const getDashboardTableByTema = async (
+  temaCode: string,
+  avdelingId?: string,
+  seksjonId?: string,
+  enhetId?: string,
+  teamIds?: string[]
+): Promise<IDashboardTable[]> => {
+  const params = new URLSearchParams()
+  if (avdelingId) params.set('avdelingId', avdelingId)
+  if (seksjonId) params.set('seksjonId', seksjonId)
+  if (enhetId) params.set('enhetId', enhetId)
+  if (teamIds) teamIds.forEach((teamId) => params.append('teamId', teamId))
+  const query = params.toString()
+  const response = await axios.get<IDashboardTable[]>(
+    `${env.backendBaseUrl}/dashboard/table/tema/${encodeURIComponent(temaCode)}${query ? `?${query}` : ''}`
+  )
+  return response.data
+}
+
 export const getDashboardAvdelingStats = async (
   avdelingId: string
 ): Promise<IDashboardDetailResponse> => {

--- a/apps/frontend-nextjs/app/components/dashboard/AvdelingDetailPage.tsx
+++ b/apps/frontend-nextjs/app/components/dashboard/AvdelingDetailPage.tsx
@@ -37,7 +37,6 @@ import {
   Link,
   List,
   LocalAlert,
-  Popover,
   ReadMore,
   Select,
   SortState,
@@ -49,6 +48,7 @@ import moment from 'moment'
 import { useEffect, useMemo, useState } from 'react'
 import { CenteredLoader } from '../common/centeredLoader/centeredLoader'
 import { AvdelingDetailReadMore } from './DashboardReadmore/AvdelingDetailReadMore'
+import { OppfyltCell, TrafficDot, getKravTrafficColor } from './DashboardTableCells'
 
 interface IProps {
   avdelingId: string
@@ -89,106 +89,6 @@ const getPvkOnlyStatusText = (
   )
     return 'Tilbakemelding fra PVO'
   return 'Under arbeid'
-}
-
-const getKravTrafficColor = (ferdig: number, total: number): string => {
-  if (total === 0) return '#C6C2BF'
-  const pct = (ferdig / total) * 100
-  if (pct >= 100) return '#06893A'
-  if (pct >= 50) return '#E67E22'
-  return '#C30000'
-}
-
-const TrafficDot = ({ color }: { color: string }) => (
-  <span
-    style={{
-      display: 'inline-block',
-      width: 12,
-      height: 12,
-      borderRadius: '50%',
-      backgroundColor: color,
-      marginRight: 6,
-      verticalAlign: 'middle',
-    }}
-  />
-)
-
-const OppfyltCell = ({ dok }: { dok: IDashboardTable }) => {
-  const [open, setOpen] = useState(false)
-  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
-  const oppfylt = dok.antallSuksesskriterierOppfylt ?? 0
-  const ikkeOppfylt = dok.antallSuksesskriterierIkkeOppfylt ?? 0
-  const totSuksess = oppfylt + ikkeOppfylt
-  const oppfyltPct = dok.oppfyltKravProsent
-
-  return (
-    <>
-      <button
-        ref={setAnchorEl}
-        onClick={() => setOpen((o) => !o)}
-        style={{
-          border: '2.5px solid #0067C5',
-          borderRadius: '10px',
-          padding: '4px 12px',
-          background: 'white',
-          color: '#0067C5',
-          fontWeight: 700,
-          fontSize: '1rem',
-          cursor: 'pointer',
-          minWidth: '52px',
-        }}
-      >
-        {oppfyltPct != null ? `${oppfyltPct}%` : '-'}
-      </button>
-      <Popover open={open} onClose={() => setOpen(false)} anchorEl={anchorEl} placement='bottom'>
-        <Popover.Content>
-          <div style={{ width: '340px' }}>
-            {totSuksess > 0 ? (
-              <>
-                <div className='flex w-full h-6 mb-4 overflow-hidden'>
-                  <div style={{ flex: oppfylt, backgroundColor: '#005B4B' }} />
-                  <div style={{ flex: ikkeOppfylt, backgroundColor: '#C30000' }} />
-                </div>
-                <div className='flex items-center gap-2 mb-2'>
-                  <span
-                    className='inline-block w-4 h-4 rounded-full'
-                    style={{ backgroundColor: '#005B4B' }}
-                  />
-                  <BodyShort>
-                    Oppfylt <strong>{oppfylt} suksesskriterier</strong>
-                  </BodyShort>
-                </div>
-                <div className='flex items-center gap-2 mb-6'>
-                  <span
-                    className='inline-block w-4 h-4 rounded-full'
-                    style={{ backgroundColor: '#C30000' }}
-                  />
-                  <BodyShort>
-                    Ikke oppfylt <strong>{ikkeOppfylt} suksesskriterier</strong>
-                  </BodyShort>
-                </div>
-                <hr className='my-4' />
-                <BodyShort className='mb-2' style={{ textAlign: 'left' }}>
-                  <strong>Oppfylt der kravet er ferdig vurdert: {oppfyltPct}%</strong>
-                </BodyShort>
-                <BodyShort
-                  size='small'
-                  style={{ textAlign: 'left', whiteSpace: 'normal', wordBreak: 'break-word' }}
-                >
-                  Etterleveren må først ha markert hele kravet som ferdig utfylt for at tallene
-                  vises her. Prosentandelen er beregnet basert på forholdet mellom suksesskriterier
-                  vurdert som oppfylt, og suksesskriterier vurdert som ikke oppfylt. Det tas ikke
-                  med suksesskriterier som ble vurdert som ikke relevant.
-                </BodyShort>
-              </>
-            ) : (
-              <BodyShort>Ingen suksesskriterier ferdig vurdert ennå.</BodyShort>
-            )}
-          </div>
-        </Popover.Content>
-      </Popover>
-    </>
-  )
 }
 
 const AvdelingDetailPage = ({ avdelingId }: IProps) => {

--- a/apps/frontend-nextjs/app/components/dashboard/DashboardTableCells.tsx
+++ b/apps/frontend-nextjs/app/components/dashboard/DashboardTableCells.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import { IDashboardTable } from '@/constants/dashboard/dashboardConstants'
+import { BodyShort, Popover } from '@navikt/ds-react'
+import { useState } from 'react'
+
+export const getKravTrafficColor = (ferdig: number, total: number): string => {
+  if (total === 0) return '#C6C2BF'
+  const pct = (ferdig / total) * 100
+  if (pct >= 100) return '#06893A'
+  if (pct >= 50) return '#E67E22'
+  return '#C30000'
+}
+
+export const TrafficDot = ({ color }: { color: string }) => (
+  <span
+    style={{
+      display: 'inline-block',
+      width: 12,
+      height: 12,
+      borderRadius: '50%',
+      backgroundColor: color,
+      marginRight: 6,
+      verticalAlign: 'middle',
+    }}
+  />
+)
+
+export const OppfyltCell = ({ dok }: { dok: IDashboardTable }) => {
+  const [open, setOpen] = useState(false)
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
+  const oppfylt = dok.antallSuksesskriterierOppfylt ?? 0
+  const ikkeOppfylt = dok.antallSuksesskriterierIkkeOppfylt ?? 0
+  const totSuksess = oppfylt + ikkeOppfylt
+  const oppfyltPct = dok.oppfyltKravProsent
+
+  return (
+    <>
+      <button
+        ref={setAnchorEl}
+        onClick={() => setOpen((o) => !o)}
+        style={{
+          border: '2.5px solid #0067C5',
+          borderRadius: '10px',
+          padding: '4px 12px',
+          background: 'white',
+          color: '#0067C5',
+          fontWeight: 700,
+          fontSize: '1rem',
+          cursor: 'pointer',
+          minWidth: '52px',
+        }}
+      >
+        {oppfyltPct != null ? `${oppfyltPct}%` : '-'}
+      </button>
+      <Popover open={open} onClose={() => setOpen(false)} anchorEl={anchorEl} placement='bottom'>
+        <Popover.Content>
+          <div style={{ width: '340px' }}>
+            {totSuksess > 0 ? (
+              <>
+                <div className='flex w-full h-6 mb-4 overflow-hidden'>
+                  <div style={{ flex: oppfylt, backgroundColor: '#005B4B' }} />
+                  <div style={{ flex: ikkeOppfylt, backgroundColor: '#C30000' }} />
+                </div>
+                <div className='flex items-center gap-2 mb-2'>
+                  <span
+                    className='inline-block w-4 h-4 rounded-full'
+                    style={{ backgroundColor: '#005B4B' }}
+                  />
+                  <BodyShort>
+                    Oppfylt <strong>{oppfylt} suksesskriterier</strong>
+                  </BodyShort>
+                </div>
+                <div className='flex items-center gap-2 mb-6'>
+                  <span
+                    className='inline-block w-4 h-4 rounded-full'
+                    style={{ backgroundColor: '#C30000' }}
+                  />
+                  <BodyShort>
+                    Ikke oppfylt <strong>{ikkeOppfylt} suksesskriterier</strong>
+                  </BodyShort>
+                </div>
+                <hr className='my-4' />
+                <BodyShort className='mb-2' style={{ textAlign: 'left' }}>
+                  <strong>Oppfylt der kravet er ferdig vurdert: {oppfyltPct}%</strong>
+                </BodyShort>
+                <BodyShort
+                  size='small'
+                  style={{ textAlign: 'left', whiteSpace: 'normal', wordBreak: 'break-word' }}
+                >
+                  Etterleveren må først ha markert hele kravet som ferdig utfylt for at tallene
+                  vises her. Prosentandelen er beregnet basert på forholdet mellom suksesskriterier
+                  vurdert som oppfylt, og suksesskriterier vurdert som ikke oppfylt. Det tas ikke
+                  med suksesskriterier som ble vurdert som ikke relevant.
+                </BodyShort>
+              </>
+            ) : (
+              <BodyShort>Ingen suksesskriterier ferdig vurdert ennå.</BodyShort>
+            )}
+          </div>
+        </Popover.Content>
+      </Popover>
+    </>
+  )
+}

--- a/apps/frontend-nextjs/app/components/dashboard/TemaDetailPage.tsx
+++ b/apps/frontend-nextjs/app/components/dashboard/TemaDetailPage.tsx
@@ -3,6 +3,7 @@
 import {
   getDashboardAvdelingStats,
   getDashboardStats,
+  getDashboardTableByTema,
   getKravDashboardStats,
   getTemaDashboardStats,
 } from '@/api/dashboard/dashboardApi'
@@ -14,11 +15,13 @@ import { RenderTagList } from '@/components/common/renderTagList/renderTagList'
 import { PageLayout } from '@/components/others/scaffold/scaffold'
 import {
   IAvdelingDashboardStats,
+  IDashboardTable,
   IKravDashboardStats,
   ISeksjonOption,
   ITemaDashboardStats,
 } from '@/constants/dashboard/dashboardConstants'
 import { IOrgEnhet } from '@/constants/teamkatalogen/teamkatalogConstants'
+import { handleSort } from '@/util/handleTableSort'
 import { noOptionMessage, selectOverrides } from '@/util/search/searchUtil'
 import { DownloadIcon, InformationSquareIcon } from '@navikt/aksel-icons'
 import {
@@ -29,7 +32,11 @@ import {
   Heading,
   InfoCard,
   Label,
+  List,
+  ReadMore,
   Select,
+  SortState,
+  Table,
   Tabs,
   Tag,
 } from '@navikt/ds-react'
@@ -38,7 +45,9 @@ import AsyncSelect from 'react-select/async'
 import { TemaDashboardDetailHowToReadmore } from './DashboardReadmore/TemaDashboardDetailHowToReadmore'
 import { TemaDashboardDetailKravReadmore } from './DashboardReadmore/TemaDashboardDetailKravReadmore'
 import { TemaDashboardDetailReadmore } from './DashboardReadmore/TemaDashboardDetailReadmore'
+import { OppfyltCell, TrafficDot, getKravTrafficColor } from './DashboardTableCells'
 import { RechartsStackedBar } from './RechartsStackedBar'
+import { StickyHorizontalScroll } from './StickyHorizontalScroll'
 import {
   IBarSegment,
   KRAV_COLORS,
@@ -291,10 +300,13 @@ const TemaDetailPage = ({ temaCode }: IProps) => {
   const [kravEnheter, setKravEnheter] = useState<IOrgEnhet[]>([])
   const [selectedKrav, setSelectedKrav] = useState<string>('')
   const [selectedTeams, setSelectedTeams] = useState<{ id: string; name: string }[]>([])
+  const [dokTableData, setDokTableData] = useState<IDashboardTable[]>([])
+  const [tableSort, setTableSort] = useState<SortState | undefined>()
   const temaRequestId = useRef(0)
   const kravRequestId = useRef(0)
   const seksjonRequestId = useRef(0)
   const kravSeksjonRequestId = useRef(0)
+  const tableRequestId = useRef(0)
 
   useEffect(() => {
     getDashboardStats()
@@ -326,6 +338,23 @@ const TemaDetailPage = ({ temaCode }: IProps) => {
           setIsLoading(false)
         }
       })
+  }, [temaCode, selectedAvdeling, selectedSeksjon, selectedEnhet, selectedTeams])
+
+  useEffect(() => {
+    const requestId = ++tableRequestId.current
+    getDashboardTableByTema(
+      temaCode,
+      selectedAvdeling || undefined,
+      selectedSeksjon || undefined,
+      selectedEnhet || undefined,
+      selectedTeams.length > 0 ? selectedTeams.map((team) => team.id) : undefined
+    )
+      .then((data) => {
+        if (requestId === tableRequestId.current) {
+          setDokTableData(data)
+        }
+      })
+      .catch((err) => console.error('Failed to fetch dashboard table for tema:', err))
   }, [temaCode, selectedAvdeling, selectedSeksjon, selectedEnhet, selectedTeams])
 
   useEffect(() => {
@@ -427,6 +456,36 @@ const TemaDetailPage = ({ temaCode }: IProps) => {
     if (!filteredKrav) return []
     return filteredKrav
   }, [filteredKrav])
+
+  const sortedTableDoks = useMemo(() => {
+    if (!tableSort) return dokTableData
+
+    const dir = tableSort.direction === 'ascending' ? 1 : -1
+    return [...dokTableData].sort((a, b) => {
+      const getValue = (dok: IDashboardTable): string | number => {
+        switch (tableSort.orderBy) {
+          case 'dok':
+            return `E${dok.etterlevelseNummer} ${dok.etterlevelseDokumentasjonTittel}`
+          case 'krav':
+            return dok.antallOppfyltKrav || 0
+          case 'oppfylt':
+            return dok.oppfyltKravProsent && dok.oppfyltKravProsent > 0 ? dok.oppfyltKravProsent : 0
+          case 'risikoeier':
+            return dok.risikoeiereData?.map((risikoeier) => risikoeier.fullName).join(', ') || ''
+          case 'team':
+            return dok.teamsData?.map((team) => team.name).join(', ') || ''
+          case 'person':
+            return dok.resourcesData?.map((resource) => resource.fullName).join(', ') || ''
+          default:
+            return ''
+        }
+      }
+      const aVal = getValue(a)
+      const bVal = getValue(b)
+      if (typeof aVal === 'number' && typeof bVal === 'number') return (aVal - bVal) * dir
+      return String(aVal).localeCompare(String(bVal)) * dir
+    })
+  }, [dokTableData, tableSort])
 
   if (isLoading && !temaStats) {
     return (
@@ -759,6 +818,7 @@ const TemaDetailPage = ({ temaCode }: IProps) => {
             <Tabs.List>
               <Tabs.Tab value='figurer' label='Vis figurer' />
               <Tabs.Tab value='nokkeltall' label='Vis nøkkeltall' />
+              <Tabs.Tab value='etterlevelsesdokumenter' label='Vis etterlevelsesdokumenter' />
             </Tabs.List>
             <Tabs.Panel value='figurer'>
               <div className='border border-gray-300 rounded-lg p-6 bg-white mt-6'>
@@ -1008,6 +1068,145 @@ const TemaDetailPage = ({ temaCode }: IProps) => {
                   </div>
                 </div>
                 <TemaDashboardDetailReadmore />
+              </div>
+            </Tabs.Panel>
+            <Tabs.Panel value='etterlevelsesdokumenter'>
+              <div className='border border-gray-300 rounded-lg p-6 bg-white mt-6'>
+                <div style={{ maxWidth: '75ch' }}>
+                  <ReadMore header='Hvordan bruker jeg denne tabellen?' className='mb-4'>
+                    <List>
+                      <List.Item>
+                        <strong>Du kan bla bortover i tabellen</strong>
+                        <br />
+                        Med mindre du bruker en veldig stor skjerm, er det sannsynligvis flere
+                        kolonner bortover til høyre som du kanskje ikke har sett.
+                      </List.Item>
+                      <List.Item>
+                        <strong>Du kan sortere tabellen etter kolonne</strong>
+                        <br />
+                        Ved å klikke på øverste rad i tabellen kan du velge om du vil sortere etter
+                        kolonnenavnet. Dette kan gjøre det enklere å finne informasjonen du lurer
+                        på.
+                      </List.Item>
+                      <List.Item>
+                        <strong>Hvordan tolke &quot;Antall krav ferdig utfylt&quot;?</strong>
+                        <br />
+                        Første tall viser hvor mange etterlevelseskrav som etterleveren har satt til
+                        &quot;ferdig utfylt&quot;. Andre tall viser totalantall krav under{' '}
+                        {temaName} som etterleveren må besvare i sitt etterlevelsesdokument.
+                      </List.Item>
+                      <List.Item>
+                        <strong>Hva betyr &quot;Oppfylt&quot;?</strong>
+                        <br />I denne kolonna kan du klikke på prosentandel og finne mer
+                        informasjon. Etterleveren må først ha markert hele kravet som ferdig utfylt
+                        for at tallene blir tatt med her. Prosentandelen er beregnet basert på
+                        forholdet mellom suksesskriterier vurdert som oppfylt, og suksesskriterier
+                        vurdert som ikke oppfylt. Det tas ikke med suksesskriterier som ble vurdert
+                        som ikke relevant.
+                      </List.Item>
+                    </List>
+                  </ReadMore>
+                </div>
+
+                {isLoading && <CenteredLoader />}
+
+                {!isLoading && (
+                  <>
+                    <StickyHorizontalScroll>
+                      <Table
+                        className='mt-4 dashboard-table'
+                        size='small'
+                        zebraStripes
+                        stickyHeader
+                        sort={tableSort}
+                        onSortChange={(sortKey) => handleSort(tableSort, setTableSort, sortKey)}
+                      >
+                        <Table.Header>
+                          <Table.Row>
+                            <Table.ColumnHeader sortable sortKey='dok'>
+                              <span className='flex flex-col'>
+                                <span>Etterlevelsesdokument</span>
+                                <span className='font-normal'>(Lenker åpnes i ny fane)</span>
+                              </span>
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader sortable sortKey='krav' align='center'>
+                              Antall krav ferdig utfylt
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader sortable sortKey='oppfylt' align='center'>
+                              Oppfylt
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader sortable sortKey='risikoeier'>
+                              Risikoeier
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader sortable sortKey='team'>
+                              Team
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader sortable sortKey='person'>
+                              Person
+                            </Table.ColumnHeader>
+                          </Table.Row>
+                        </Table.Header>
+                        <Table.Body>
+                          {sortedTableDoks.map((dok) => (
+                            <Table.Row key={dok.etterlevelseDokumentasjonId}>
+                              <Table.DataCell className='dashboard-cell-wide'>
+                                <AkselLink
+                                  href={`/dokumentasjon/${dok.etterlevelseDokumentasjonId}`}
+                                  target='_blank'
+                                >
+                                  E{dok.etterlevelseNummer}.{dok.etterlevelseDokumentVersjon}{' '}
+                                  {dok.etterlevelseDokumentasjonTittel}
+                                </AkselLink>
+                              </Table.DataCell>
+                              <Table.DataCell align='center'>
+                                <TrafficDot
+                                  color={getKravTrafficColor(
+                                    dok.antallOppfyltKrav || 0,
+                                    dok.antallKrav || 0
+                                  )}
+                                />
+                                {dok.antallOppfyltKrav} av {dok.antallKrav}
+                              </Table.DataCell>
+                              <Table.DataCell align='center'>
+                                <OppfyltCell dok={dok} />
+                              </Table.DataCell>
+                              <Table.DataCell>
+                                {dok.risikoeiereData && dok.risikoeiereData.length > 0
+                                  ? dok.risikoeiereData.map((risikoeier, index) => (
+                                      <div key={`${risikoeier.navIdent}-${index}`}>
+                                        {risikoeier.fullName}
+                                      </div>
+                                    ))
+                                  : '-'}
+                              </Table.DataCell>
+                              <Table.DataCell>
+                                {dok.teamsData && dok.teamsData.length > 0
+                                  ? dok.teamsData.map((team) => (
+                                      <div key={team.id}>{team.name}</div>
+                                    ))
+                                  : '-'}
+                              </Table.DataCell>
+                              <Table.DataCell>
+                                {dok.resourcesData && dok.resourcesData.length > 0
+                                  ? dok.resourcesData.map((resource, index) => (
+                                      <div key={`${resource.navIdent}-${index}`}>
+                                        {resource.fullName}
+                                      </div>
+                                    ))
+                                  : '-'}
+                              </Table.DataCell>
+                            </Table.Row>
+                          ))}
+                        </Table.Body>
+                      </Table>
+                    </StickyHorizontalScroll>
+                    {sortedTableDoks.length === 0 && (
+                      <BodyShort className='mt-4 text-gray-500'>
+                        Ingen treff på valgte filtre
+                      </BodyShort>
+                    )}
+                  </>
+                )}
               </div>
             </Tabs.Panel>
           </Tabs>


### PR DESCRIPTION
Add a new "Vis etterlevelsesdokumenter" tab to the "Overordnet for alle krav" section on the tema dashboard, reusing the document table from AvdelingDetailPage (krav progress, oppfylt %, risikoeier, team, person).

- Add GET /dashboard/table/tema/{temaCode} endpoint
- Add DashboardService.getDashboardTableByTema, refactor getDashboardTable to share a buildDashboardTable helper
- Extract TrafficDot, getKravTrafficColor and OppfyltCell into shared DashboardTableCells component, reused by both Avdeling- and TemaDetailPage
- Add getDashboardTableByTema to dashboardApi